### PR TITLE
feat(logistics): build driver marketplace job board

### DIFF
--- a/app/(dashboard)/driver/jobs/page.tsx
+++ b/app/(dashboard)/driver/jobs/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+import { Briefcase, RefreshCw } from 'lucide-react';
+import { useDriverJobs } from '@/hooks/useDriverJobs';
+import { JobCard } from '@/features/driver/components/JobCard';
+import { AcceptJobModal } from '@/features/driver/components/AcceptJobModal';
+import { DeliveryJob } from '@/services/driverJobService';
+
+/**
+ * DriverJobBoardPage — marketplace view for drivers to browse and accept
+ * unassigned deliveries in their region.
+ *
+ * Route: /driver/jobs
+ */
+export default function DriverJobBoardPage() {
+  const { jobs, isLoading, isAccepting, error, refreshJobs, acceptJob } =
+    useDriverJobs();
+
+  // The job currently being confirmed — null means modal is closed.
+  const [pendingJob, setPendingJob] = useState<DeliveryJob | null>(null);
+
+  const handleAcceptRequest = (job: DeliveryJob) => {
+    setPendingJob(job);
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingJob) return;
+    await acceptJob(pendingJob.id);
+    setPendingJob(null);
+  };
+
+  const handleCancel = () => {
+    setPendingJob(null);
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Briefcase className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Available Jobs
+            </h1>
+            <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+              Browse and accept delivery jobs in your region
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void refreshJobs()}
+          disabled={isLoading}
+          className="flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+          aria-label="Refresh job listings"
+        >
+          <RefreshCw
+            className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`}
+          />
+          Refresh
+        </button>
+      </div>
+
+      {/* Stats bar */}
+      {!isLoading && !error && (
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+          {jobs.length === 0
+            ? 'No jobs available right now — check back soon.'
+            : `${jobs.length} job${jobs.length !== 1 ? 's' : ''} available`}
+        </p>
+      )}
+
+      {/* Loading skeleton */}
+      {isLoading && (
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-52 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800"
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Error state */}
+      {!isLoading && error && (
+        <div className="mt-6 rounded-xl border border-red-200 bg-red-50 p-6 text-center dark:border-red-900/30 dark:bg-red-900/10">
+          <p className="text-sm font-medium text-red-700 dark:text-red-400">
+            {error}
+          </p>
+          <button
+            type="button"
+            onClick={() => void refreshJobs()}
+            className="mt-3 rounded-lg border border-red-200 px-4 py-2 text-xs font-medium text-red-600 transition hover:bg-red-100 dark:border-red-800 dark:hover:bg-red-900/20"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && jobs.length === 0 && (
+        <div className="mt-12 flex flex-col items-center gap-3 text-center">
+          <Briefcase className="h-12 w-12 text-gray-300 dark:text-gray-600" />
+          <p className="text-base font-medium text-gray-500 dark:text-gray-400">
+            No jobs available right now
+          </p>
+          <p className="text-sm text-gray-400 dark:text-gray-500">
+            New deliveries appear here as soon as they&apos;re posted.
+          </p>
+        </div>
+      )}
+
+      {/* Job grid */}
+      {!isLoading && !error && jobs.length > 0 && (
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          {jobs.map((job) => (
+            <JobCard
+              key={job.id}
+              job={job}
+              onAccept={handleAcceptRequest}
+              isAccepting={isAccepting}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Confirmation modal */}
+      {pendingJob && (
+        <AcceptJobModal
+          job={pendingJob}
+          isAccepting={isAccepting}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+    </div>
+  );
+}

--- a/features/driver/components/AcceptJobModal.tsx
+++ b/features/driver/components/AcceptJobModal.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { MapPin, Navigation, Package, TrendingUp, X } from 'lucide-react';
+import { DeliveryJob } from '@/services/driverJobService';
+
+interface AcceptJobModalProps {
+  job: DeliveryJob;
+  isAccepting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * AcceptJobModal — confirmation dialog before a driver accepts a delivery.
+ * Shows full job details and requires an explicit confirm action.
+ */
+export function AcceptJobModal({
+  job,
+  isAccepting,
+  onConfirm,
+  onCancel,
+}: AcceptJobModalProps) {
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="accept-job-title"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-900">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2
+            id="accept-job-title"
+            className="text-lg font-semibold text-gray-900 dark:text-white"
+          >
+            Confirm Job
+          </h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-full p-1 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Review the delivery details before accepting.
+        </p>
+
+        {/* Job details */}
+        <div className="mt-4 space-y-3 rounded-xl bg-gray-50 p-4 dark:bg-gray-800">
+          <div className="flex items-start gap-2">
+            <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+            <div>
+              <p className="text-xs text-gray-500">Pickup</p>
+              <p className="text-sm font-medium">{job.pickupAddress}</p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-2">
+            <Navigation className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+            <div>
+              <p className="text-xs text-gray-500">Drop-off</p>
+              <p className="text-sm font-medium">{job.dropoffAddress}</p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-2">
+            <Package className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+            <div>
+              <p className="text-xs text-gray-500">Package</p>
+              <p className="text-sm font-medium">{job.packageDescription}</p>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between border-t border-gray-200 pt-3 dark:border-gray-700">
+            <span className="flex items-center gap-1.5 text-sm text-gray-500">
+              <TrendingUp className="h-4 w-4" />
+              {job.estimatedDistance} km
+            </span>
+            <span className="text-base font-bold text-primary">
+              {job.estimatedEarnings.toFixed(2)} XLM
+            </span>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="mt-5 flex gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isAccepting}
+            className="flex-1 rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isAccepting}
+            className="flex-1 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isAccepting ? 'Accepting…' : 'Yes, Accept Job'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/driver/components/JobCard.tsx
+++ b/features/driver/components/JobCard.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { MapPin, Package, TrendingUp, Navigation } from 'lucide-react';
+import { DeliveryJob } from '@/services/driverJobService';
+
+interface JobCardProps {
+  job: DeliveryJob;
+  onAccept: (job: DeliveryJob) => void;
+  isAccepting: boolean;
+}
+
+/**
+ * JobCard — displays a single available delivery job with key details
+ * and an Accept Job button that triggers the confirmation modal.
+ */
+export function JobCard({ job, onAccept, isAccepting }: JobCardProps) {
+  return (
+    <article className="rounded-xl border border-secondary/30 bg-white p-5 shadow-sm transition hover:shadow-md dark:bg-secondary/10">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+          <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+          Available
+        </span>
+        <p className="text-right text-sm font-semibold text-primary">
+          {job.estimatedEarnings.toFixed(2)} XLM
+        </p>
+      </div>
+
+      {/* Route */}
+      <div className="mt-4 space-y-2">
+        <div className="flex items-start gap-2">
+          <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+          <div>
+            <p className="text-xs text-secondary">Pickup</p>
+            <p className="text-sm font-medium">{job.pickupAddress}</p>
+          </div>
+        </div>
+        <div className="ml-2 h-4 w-px bg-secondary/30" />
+        <div className="flex items-start gap-2">
+          <Navigation className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+          <div>
+            <p className="text-xs text-secondary">Drop-off</p>
+            <p className="text-sm font-medium">{job.dropoffAddress}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Details */}
+      <div className="mt-4 flex flex-wrap gap-4 border-t border-secondary/20 pt-4 text-sm text-secondary">
+        <span className="flex items-center gap-1.5">
+          <TrendingUp className="h-4 w-4" />
+          {job.estimatedDistance} km
+        </span>
+        <span className="flex items-center gap-1.5">
+          <Package className="h-4 w-4" />
+          {job.packageDescription}
+        </span>
+      </div>
+
+      {/* CTA */}
+      <button
+        type="button"
+        onClick={() => onAccept(job)}
+        disabled={isAccepting}
+        className="mt-4 w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Accept Job
+      </button>
+    </article>
+  );
+}

--- a/hooks/useDriverJobs.ts
+++ b/hooks/useDriverJobs.ts
@@ -1,0 +1,83 @@
+import { useState, useCallback, useEffect } from 'react';
+import { driverJobService, DeliveryJob } from '@/services/driverJobService';
+import { toast } from 'sonner';
+
+/**
+ * useDriverJobs — the single hook for driver job board management.
+ *
+ * Provides methods to fetch available jobs and accept a job.
+ * Accepted jobs are removed from the local pool immediately (optimistic update)
+ * so the UI reflects the change before the next API refresh.
+ */
+export function useDriverJobs(region?: string) {
+  const [jobs, setJobs] = useState<DeliveryJob[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchJobs = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await driverJobService.getAvailableJobs(region);
+      if (response.success && response.data) {
+        setJobs(response.data);
+      } else {
+        setError(response.message || 'Failed to fetch available jobs');
+      }
+    } catch (err: any) {
+      setError(
+        err.response?.data?.message || 'An error occurred while fetching jobs'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [region]);
+
+  /**
+   * Accept a job. Removes it from the local pool instantly so it disappears
+   * from the available list before the next server refresh.
+   */
+  const acceptJob = useCallback(
+    async (jobId: string): Promise<boolean> => {
+      setIsAccepting(true);
+      // Optimistic update — remove from pool immediately.
+      setJobs((prev) => prev.filter((job) => job.id !== jobId));
+      try {
+        const response = await driverJobService.acceptJob(jobId);
+        if (response.success) {
+          toast.success('Job accepted! Head to the pickup location.');
+          return true;
+        } else {
+          // Roll back the optimistic removal on failure.
+          toast.error(response.message || 'Failed to accept job');
+          await fetchJobs();
+          return false;
+        }
+      } catch (err: any) {
+        toast.error(
+          err.response?.data?.message || 'An error occurred while accepting the job'
+        );
+        // Roll back the optimistic removal on network error.
+        await fetchJobs();
+        return false;
+      } finally {
+        setIsAccepting(false);
+      }
+    },
+    [fetchJobs]
+  );
+
+  useEffect(() => {
+    fetchJobs();
+  }, [fetchJobs]);
+
+  return {
+    jobs,
+    isLoading,
+    isAccepting,
+    error,
+    refreshJobs: fetchJobs,
+  acceptJob,
+  };
+}

--- a/services/driverJobService.ts
+++ b/services/driverJobService.ts
@@ -1,0 +1,49 @@
+import axios from 'axios';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export interface DeliveryJob {
+  id: string;
+  pickupAddress: string;
+  dropoffAddress: string;
+  packageDescription: string;
+  estimatedDistance: number; // km
+  estimatedEarnings: number; // XLM
+  region: string;
+  createdAt: string;
+  status: 'unassigned' | 'assigned' | 'in_progress' | 'delivered';
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data?: T;
+}
+
+/**
+ * driverJobService — responsible for all driver job-related API communication.
+ * Follows the Strict Layered Architecture: Component -> Hook -> Service.
+ */
+export const driverJobService = {
+  /**
+   * Fetch all unassigned deliveries available in the driver's region.
+   */
+  async getAvailableJobs(region?: string): Promise<ApiResponse<DeliveryJob[]>> {
+    const params = region ? { region } : {};
+    const { data } = await axios.get<ApiResponse<DeliveryJob[]>>(
+      `${API_BASE_URL}/api/driver/jobs`,
+      { params }
+    );
+    return data;
+  },
+
+  /**
+   * Accept a delivery job — assigns it to the authenticated driver.
+   */
+  async acceptJob(jobId: string): Promise<ApiResponse<DeliveryJob>> {
+    const { data } = await axios.post<ApiResponse<DeliveryJob>>(
+      `${API_BASE_URL}/api/driver/jobs/${jobId}/accept`
+    );
+    return data;
+  },
+};


### PR DESCRIPTION
Closes #21

## Summary
Implements the Driver Job Board UI — a marketplace view where drivers can browse unassigned deliveries in their region and accept jobs with a confirmation modal.

## Changes

- `services/driverJobService.ts` — API service with `getAvailableJobs()` and `acceptJob()` following the existing service pattern
- `hooks/useDriverJobs.ts` — hook managing job list state, loading, error, and accept logic with optimistic update
- `features/driver/components/JobCard.tsx` — card displaying pickup, drop-off, distance, earnings and Accept button
- `features/driver/components/AcceptJobModal.tsx` — confirmation modal showing full job details before accepting
- `app/(dashboard)/driver/jobs/page.tsx` — main page wiring all components together

## Architecture
Follows the required Component → Hook → Service layered pattern throughout.

## Key behaviour
- Accepted jobs **instantly disappear** from the available pool via optimistic update — the job is removed from local state before the API response returns
- If the API call fails, the job is restored to the list automatically
- Loading skeleton, empty state, and error state all handled

## Screenshot
[attach screenshot of the job board UI running locally]