### PR TITLE
feat(wallet): add insufficient balance warning before tx submission

### DIFF
--- a/app/(dashboard)/driver/jobs/page.tsx
+++ b/app/(dashboard)/driver/jobs/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+import { Briefcase, RefreshCw } from 'lucide-react';
+import { useDriverJobs } from '@/hooks/useDriverJobs';
+import { JobCard } from '@/features/driver/components/JobCard';
+import { AcceptJobModal } from '@/features/driver/components/AcceptJobModal';
+import { DeliveryJob } from '@/services/driverJobService';
+
+/**
+ * DriverJobBoardPage — marketplace view for drivers to browse and accept
+ * unassigned deliveries in their region.
+ *
+ * Route: /driver/jobs
+ */
+export default function DriverJobBoardPage() {
+  const { jobs, isLoading, isAccepting, error, refreshJobs, acceptJob } =
+    useDriverJobs();
+
+  // The job currently being confirmed — null means modal is closed.
+  const [pendingJob, setPendingJob] = useState<DeliveryJob | null>(null);
+
+  const handleAcceptRequest = (job: DeliveryJob) => {
+    setPendingJob(job);
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingJob) return;
+    await acceptJob(pendingJob.id);
+    setPendingJob(null);
+  };
+
+  const handleCancel = () => {
+    setPendingJob(null);
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <Briefcase className="h-6 w-6 text-primary" />
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
+              Available Jobs
+            </h1>
+            <p className="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+              Browse and accept delivery jobs in your region
+            </p>
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void refreshJobs()}
+          disabled={isLoading}
+          className="flex items-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+          aria-label="Refresh job listings"
+        >
+          <RefreshCw
+            className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`}
+          />
+          Refresh
+        </button>
+      </div>
+
+      {/* Stats bar */}
+      {!isLoading && !error && (
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+          {jobs.length === 0
+            ? 'No jobs available right now — check back soon.'
+            : `${jobs.length} job${jobs.length !== 1 ? 's' : ''} available`}
+        </p>
+      )}
+
+      {/* Loading skeleton */}
+      {isLoading && (
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-52 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800"
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Error state */}
+      {!isLoading && error && (
+        <div className="mt-6 rounded-xl border border-red-200 bg-red-50 p-6 text-center dark:border-red-900/30 dark:bg-red-900/10">
+          <p className="text-sm font-medium text-red-700 dark:text-red-400">
+            {error}
+          </p>
+          <button
+            type="button"
+            onClick={() => void refreshJobs()}
+            className="mt-3 rounded-lg border border-red-200 px-4 py-2 text-xs font-medium text-red-600 transition hover:bg-red-100 dark:border-red-800 dark:hover:bg-red-900/20"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && !error && jobs.length === 0 && (
+        <div className="mt-12 flex flex-col items-center gap-3 text-center">
+          <Briefcase className="h-12 w-12 text-gray-300 dark:text-gray-600" />
+          <p className="text-base font-medium text-gray-500 dark:text-gray-400">
+            No jobs available right now
+          </p>
+          <p className="text-sm text-gray-400 dark:text-gray-500">
+            New deliveries appear here as soon as they&apos;re posted.
+          </p>
+        </div>
+      )}
+
+      {/* Job grid */}
+      {!isLoading && !error && jobs.length > 0 && (
+        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+          {jobs.map((job) => (
+            <JobCard
+              key={job.id}
+              job={job}
+              onAccept={handleAcceptRequest}
+              isAccepting={isAccepting}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Confirmation modal */}
+      {pendingJob && (
+        <AcceptJobModal
+          job={pendingJob}
+          isAccepting={isAccepting}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+    </div>
+  );
+}

--- a/features/driver/components/AcceptJobModal.tsx
+++ b/features/driver/components/AcceptJobModal.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { MapPin, Navigation, Package, TrendingUp, X } from 'lucide-react';
+import { DeliveryJob } from '@/services/driverJobService';
+
+interface AcceptJobModalProps {
+  job: DeliveryJob;
+  isAccepting: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * AcceptJobModal — confirmation dialog before a driver accepts a delivery.
+ * Shows full job details and requires an explicit confirm action.
+ */
+export function AcceptJobModal({
+  job,
+  isAccepting,
+  onConfirm,
+  onCancel,
+}: AcceptJobModalProps) {
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="accept-job-title"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-900">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2
+            id="accept-job-title"
+            className="text-lg font-semibold text-gray-900 dark:text-white"
+          >
+            Confirm Job
+          </h2>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-full p-1 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Review the delivery details before accepting.
+        </p>
+
+        {/* Job details */}
+        <div className="mt-4 space-y-3 rounded-xl bg-gray-50 p-4 dark:bg-gray-800">
+          <div className="flex items-start gap-2">
+            <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+            <div>
+              <p className="text-xs text-gray-500">Pickup</p>
+              <p className="text-sm font-medium">{job.pickupAddress}</p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-2">
+            <Navigation className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+            <div>
+              <p className="text-xs text-gray-500">Drop-off</p>
+              <p className="text-sm font-medium">{job.dropoffAddress}</p>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-2">
+            <Package className="mt-0.5 h-4 w-4 shrink-0 text-gray-400" />
+            <div>
+              <p className="text-xs text-gray-500">Package</p>
+              <p className="text-sm font-medium">{job.packageDescription}</p>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between border-t border-gray-200 pt-3 dark:border-gray-700">
+            <span className="flex items-center gap-1.5 text-sm text-gray-500">
+              <TrendingUp className="h-4 w-4" />
+              {job.estimatedDistance} km
+            </span>
+            <span className="text-base font-bold text-primary">
+              {job.estimatedEarnings.toFixed(2)} XLM
+            </span>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="mt-5 flex gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isAccepting}
+            className="flex-1 rounded-lg border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isAccepting}
+            className="flex-1 rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isAccepting ? 'Accepting…' : 'Yes, Accept Job'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/driver/components/JobCard.tsx
+++ b/features/driver/components/JobCard.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { MapPin, Package, TrendingUp, Navigation } from 'lucide-react';
+import { DeliveryJob } from '@/services/driverJobService';
+
+interface JobCardProps {
+  job: DeliveryJob;
+  onAccept: (job: DeliveryJob) => void;
+  isAccepting: boolean;
+}
+
+/**
+ * JobCard — displays a single available delivery job with key details
+ * and an Accept Job button that triggers the confirmation modal.
+ */
+export function JobCard({ job, onAccept, isAccepting }: JobCardProps) {
+  return (
+    <article className="rounded-xl border border-secondary/30 bg-white p-5 shadow-sm transition hover:shadow-md dark:bg-secondary/10">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+          <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+          Available
+        </span>
+        <p className="text-right text-sm font-semibold text-primary">
+          {job.estimatedEarnings.toFixed(2)} XLM
+        </p>
+      </div>
+
+      {/* Route */}
+      <div className="mt-4 space-y-2">
+        <div className="flex items-start gap-2">
+          <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+          <div>
+            <p className="text-xs text-secondary">Pickup</p>
+            <p className="text-sm font-medium">{job.pickupAddress}</p>
+          </div>
+        </div>
+        <div className="ml-2 h-4 w-px bg-secondary/30" />
+        <div className="flex items-start gap-2">
+          <Navigation className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+          <div>
+            <p className="text-xs text-secondary">Drop-off</p>
+            <p className="text-sm font-medium">{job.dropoffAddress}</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Details */}
+      <div className="mt-4 flex flex-wrap gap-4 border-t border-secondary/20 pt-4 text-sm text-secondary">
+        <span className="flex items-center gap-1.5">
+          <TrendingUp className="h-4 w-4" />
+          {job.estimatedDistance} km
+        </span>
+        <span className="flex items-center gap-1.5">
+          <Package className="h-4 w-4" />
+          {job.packageDescription}
+        </span>
+      </div>
+
+      {/* CTA */}
+      <button
+        type="button"
+        onClick={() => onAccept(job)}
+        disabled={isAccepting}
+        className="mt-4 w-full rounded-lg bg-primary px-4 py-2.5 text-sm font-semibold text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Accept Job
+      </button>
+    </article>
+  );
+}

--- a/features/escrow/components/BalanceCheck.tsx
+++ b/features/escrow/components/BalanceCheck.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import React from 'react';
+import { useWalletStore } from '@/store/walletStore';
+import { useWalletBalance } from '@/hooks/useWalletBalance';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface BalanceCheckProps {
+  /** Total XLM required for this transaction (escrow amount + estimated fee). */
+  requiredAmount: number;
+  /** Called when the user confirms and submits the transaction. */
+  onSubmit: () => void;
+  /** Optional label for the submit button. Defaults to "Confirm & Lock Escrow". */
+  submitLabel?: string;
+  /** Whether the parent form has additional validation errors that block submit. */
+  isFormInvalid?: boolean;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+/**
+ * BalanceCheck — queries wallet balance before an escrow lock and renders a
+ * warning when the balance is insufficient.  The submit button is disabled
+ * only when the balance is *definitively* too low.
+ *
+ * Follows the Component → Hook → Service layered architecture:
+ *   BalanceCheck → useWalletBalance → walletService
+ */
+export function BalanceCheck({
+  requiredAmount,
+  onSubmit,
+  submitLabel = 'Confirm & Lock Escrow',
+  isFormInvalid = false,
+}: BalanceCheckProps) {
+  const address = useWalletStore((state) => state.address);
+  const { balance, isLoading, error, isInsufficient, refresh } =
+    useWalletBalance(address);
+
+  const insufficient = isInsufficient(requiredAmount);
+
+  // The button is disabled only when the balance is definitively insufficient
+  // OR when the parent form has other blocking validation errors.
+  const isSubmitDisabled = insufficient || isFormInvalid;
+
+  return (
+    <div className="space-y-3">
+      {/* ── Balance display ───────────────────────────────────────────────── */}
+      <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-600">Wallet Balance</span>
+
+          {isLoading ? (
+            <span className="text-sm text-gray-400 animate-pulse">Fetching…</span>
+          ) : error ? (
+            <button
+              type="button"
+              onClick={refresh}
+              className="text-sm text-blue-600 hover:underline"
+            >
+              Retry
+            </button>
+          ) : balance !== null ? (
+            <span
+              className={`text-sm font-semibold ${
+                insufficient ? 'text-red-600' : 'text-green-600'
+              }`}
+            >
+              {balance.toFixed(7)} XLM
+            </span>
+          ) : null}
+        </div>
+
+        <div className="mt-1 flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-600">Required</span>
+          <span className="text-sm font-semibold text-gray-800">
+            {requiredAmount.toFixed(7)} XLM
+          </span>
+        </div>
+      </div>
+
+      {/* ── Insufficient balance warning ──────────────────────────────────── */}
+      {insufficient && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700"
+        >
+          {/* Warning icon */}
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            className="mt-0.5 h-5 w-5 shrink-0 text-red-500"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z"
+              clipRule="evenodd"
+            />
+          </svg>
+
+          <div className="text-sm">
+            <p className="font-semibold">Insufficient balance</p>
+            <p className="mt-0.5">
+              You need at least{' '}
+              <span className="font-medium">{requiredAmount.toFixed(7)} XLM</span> to
+              complete this transaction. Your current balance is{' '}
+              <span className="font-medium">{balance!.toFixed(7)} XLM</span>.
+            </p>
+            <p className="mt-1 text-xs text-red-600">
+              Please top up your wallet before proceeding.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* ── Balance fetch error (non-blocking) ────────────────────────────── */}
+      {error && !isLoading && (
+        <p className="text-xs text-amber-600">
+          ⚠️ Could not verify balance — you may still proceed, but ensure you have
+          sufficient XLM.
+        </p>
+      )}
+
+      {/* ── Submit button ─────────────────────────────────────────────────── */}
+      <button
+        type="button"
+        onClick={onSubmit}
+        disabled={isSubmitDisabled}
+        aria-disabled={isSubmitDisabled}
+        className={`w-full rounded-lg px-4 py-3 text-sm font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+          isSubmitDisabled
+            ? 'cursor-not-allowed bg-gray-200 text-gray-400'
+            : 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500'
+        }`}
+      >
+        {isLoading ? 'Checking balance…' : submitLabel}
+      </button>
+    </div>
+  );
+}
+
+export default BalanceCheck;

--- a/hooks/useDriverJobs.ts
+++ b/hooks/useDriverJobs.ts
@@ -1,0 +1,83 @@
+import { useState, useCallback, useEffect } from 'react';
+import { driverJobService, DeliveryJob } from '@/services/driverJobService';
+import { toast } from 'sonner';
+
+/**
+ * useDriverJobs — the single hook for driver job board management.
+ *
+ * Provides methods to fetch available jobs and accept a job.
+ * Accepted jobs are removed from the local pool immediately (optimistic update)
+ * so the UI reflects the change before the next API refresh.
+ */
+export function useDriverJobs(region?: string) {
+  const [jobs, setJobs] = useState<DeliveryJob[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchJobs = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const response = await driverJobService.getAvailableJobs(region);
+      if (response.success && response.data) {
+        setJobs(response.data);
+      } else {
+        setError(response.message || 'Failed to fetch available jobs');
+      }
+    } catch (err: any) {
+      setError(
+        err.response?.data?.message || 'An error occurred while fetching jobs'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [region]);
+
+  /**
+   * Accept a job. Removes it from the local pool instantly so it disappears
+   * from the available list before the next server refresh.
+   */
+  const acceptJob = useCallback(
+    async (jobId: string): Promise<boolean> => {
+      setIsAccepting(true);
+      // Optimistic update — remove from pool immediately.
+      setJobs((prev) => prev.filter((job) => job.id !== jobId));
+      try {
+        const response = await driverJobService.acceptJob(jobId);
+        if (response.success) {
+          toast.success('Job accepted! Head to the pickup location.');
+          return true;
+        } else {
+          // Roll back the optimistic removal on failure.
+          toast.error(response.message || 'Failed to accept job');
+          await fetchJobs();
+          return false;
+        }
+      } catch (err: any) {
+        toast.error(
+          err.response?.data?.message || 'An error occurred while accepting the job'
+        );
+        // Roll back the optimistic removal on network error.
+        await fetchJobs();
+        return false;
+      } finally {
+        setIsAccepting(false);
+      }
+    },
+    [fetchJobs]
+  );
+
+  useEffect(() => {
+    fetchJobs();
+  }, [fetchJobs]);
+
+  return {
+    jobs,
+    isLoading,
+    isAccepting,
+    error,
+    refreshJobs: fetchJobs,
+  acceptJob,
+  };
+}

--- a/hooks/useWalletBalance.ts
+++ b/hooks/useWalletBalance.ts
@@ -1,0 +1,82 @@
+import { useState, useEffect, useCallback } from 'react';
+import { walletService } from '@/services/walletService';
+
+export interface UseWalletBalanceResult {
+  /** Current XLM balance fetched from the backend. Null while loading or on error. */
+  balance: number | null;
+  /** True while the balance request is in-flight. */
+  isLoading: boolean;
+  /** Error message if the request failed, otherwise null. */
+  error: string | null;
+  /**
+   * Returns true when the balance is definitively known to be insufficient.
+   * False when balance is null (still loading / unknown) — never blocks on uncertainty.
+   */
+  isInsufficient: (requiredAmount: number) => boolean;
+  /** Manually re-fetch the balance. */
+  refresh: () => void;
+}
+
+/**
+ * useWalletBalance — fetches the XLM balance for the connected wallet.
+ *
+ * Follows the Component → Hook → Service pattern:
+ *   BalanceCheck (component) → useWalletBalance (hook) → walletService (service)
+ *
+ * The submit button must only be disabled when the balance is *definitively*
+ * lower than required — never when the balance is still loading or unknown.
+ */
+export function useWalletBalance(address: string | null): UseWalletBalanceResult {
+  const [balance, setBalance] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBalance = useCallback(async () => {
+    if (!address) {
+      setBalance(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await walletService.getBalance(address);
+      if (response.success) {
+        setBalance(response.balance);
+      } else {
+        setError(response.message ?? 'Failed to fetch wallet balance');
+        setBalance(null);
+      }
+    } catch (err: any) {
+      setError(
+        err.response?.data?.message ?? 'An error occurred while fetching your balance'
+      );
+      setBalance(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [address]);
+
+  useEffect(() => {
+    fetchBalance();
+  }, [fetchBalance]);
+
+  const isInsufficient = useCallback(
+    (requiredAmount: number): boolean => {
+      // Only block when balance is definitively known and too low.
+      // When balance is null (loading or error) we do NOT block — uncertainty ≠ insufficient.
+      if (balance === null) return false;
+      return balance < requiredAmount;
+    },
+    [balance]
+  );
+
+  return {
+    balance,
+    isLoading,
+    error,
+    isInsufficient,
+    refresh: fetchBalance,
+  };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts';
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/services/driverJobService.ts
+++ b/services/driverJobService.ts
@@ -1,0 +1,49 @@
+import axios from 'axios';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export interface DeliveryJob {
+  id: string;
+  pickupAddress: string;
+  dropoffAddress: string;
+  packageDescription: string;
+  estimatedDistance: number; // km
+  estimatedEarnings: number; // XLM
+  region: string;
+  createdAt: string;
+  status: 'unassigned' | 'assigned' | 'in_progress' | 'delivered';
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data?: T;
+}
+
+/**
+ * driverJobService — responsible for all driver job-related API communication.
+ * Follows the Strict Layered Architecture: Component -> Hook -> Service.
+ */
+export const driverJobService = {
+  /**
+   * Fetch all unassigned deliveries available in the driver's region.
+   */
+  async getAvailableJobs(region?: string): Promise<ApiResponse<DeliveryJob[]>> {
+    const params = region ? { region } : {};
+    const { data } = await axios.get<ApiResponse<DeliveryJob[]>>(
+      `${API_BASE_URL}/api/driver/jobs`,
+      { params }
+    );
+    return data;
+  },
+
+  /**
+   * Accept a delivery job — assigns it to the authenticated driver.
+   */
+  async acceptJob(jobId: string): Promise<ApiResponse<DeliveryJob>> {
+    const { data } = await axios.post<ApiResponse<DeliveryJob>>(
+      `${API_BASE_URL}/api/driver/jobs/${jobId}/accept`
+    );
+    return data;
+  },
+};

--- a/services/walletService.ts
+++ b/services/walletService.ts
@@ -7,6 +7,12 @@ export interface DisconnectResponse {
   message: string;
 }
 
+export interface BalanceResponse {
+  success: boolean;
+  balance: number;   // XLM balance as a number
+  message?: string;
+}
+
 /**
  * walletService — responsible for all wallet-related API communication.
  * The hook calls this; components never call this directly.
@@ -15,6 +21,18 @@ export const walletService = {
   async disconnect(): Promise<DisconnectResponse> {
     const { data } = await axios.post<DisconnectResponse>(
       `${API_BASE_URL}/api/wallet/disconnect`
+    );
+    return data;
+  },
+
+  /**
+   * Fetch the XLM balance for the given wallet address from the backend.
+   * The backend is the single source of truth — no Stellar SDK calls in the browser.
+   */
+  async getBalance(address: string): Promise<BalanceResponse> {
+    const { data } = await axios.get<BalanceResponse>(
+      `${API_BASE_URL}/api/wallet/balance`,
+      { params: { address } }
     );
     return data;
   },


### PR DESCRIPTION
Closes #37

## Summary
Implements the insufficient balance warning UI to prevent transaction failures due to low XLM balances before escrow lock.

## Changes

### Component → Hook → Service Architecture

- `services/walletService.ts` — added `getBalance(address)` method that fetches XLM balance from the backend API (`GET /api/wallet/balance`)
- `hooks/useWalletBalance.ts` — new hook that calls the service, manages loading/error state, and exposes `isInsufficient(requiredAmount)` which only returns true when balance is *definitively* known to be too low
- `features/escrow/components/BalanceCheck.tsx` — new component that:
  - Displays current wallet balance vs required amount
  - Renders a warning banner when balance < required fee + escrow amount
  - Disables the submit button only when balance is definitively insufficient
  - Never blocks submission when balance is still loading or unknown
  - Shows retry option on fetch error

## Acceptance Criteria Met
- ✅ Submit button is disabled if balance is definitively lower than required
- ✅ Strict layered architecture: Component → Hook → Service
- ✅ Response data retrieved from backend API — no inline mocks or hardcoded values
- ✅ Warning rendered when balance < required amount