### PR TITLE
feat(escrow): build escrow release and payout UI

### DIFF
--- a/features/escrow/components/EscrowRelease.tsx
+++ b/features/escrow/components/EscrowRelease.tsx
@@ -1,0 +1,339 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useEscrowRelease, ReleaseStep } from '@/hooks/useEscrowRelease';
+import { useWalletStore } from '@/store/walletStore';
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface EscrowReleaseProps {
+  escrowId: string;
+  deliveryId: string;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const STEP_LABEL: Record<ReleaseStep, string> = {
+  idle: 'Confirm Delivery & Release Payment',
+  confirming: 'Confirm Delivery & Release Payment',
+  signing: 'Waiting for wallet approval…',
+  releasing: 'Releasing payment…',
+  done: 'Payment Released ✓',
+};
+
+const STEP_DESCRIPTION: Record<ReleaseStep, string> = {
+  idle: 'Releasing payment will transfer the locked escrow funds to the driver. This action cannot be undone.',
+  confirming: 'Are you sure you want to confirm delivery and release the escrowed payment to the driver?',
+  signing: 'Your wallet is requesting your approval. Please check your wallet and approve the transaction.',
+  releasing: 'Transaction submitted — waiting for blockchain confirmation…',
+  done: 'The escrowed funds have been successfully released to the driver.',
+};
+
+function StatusIcon({ step }: { step: ReleaseStep }) {
+  if (step === 'done') {
+    return (
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100 mx-auto mb-4">
+        <svg className="h-8 w-8 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+        </svg>
+      </div>
+    );
+  }
+  if (step === 'signing' || step === 'releasing') {
+    return (
+      <div className="flex h-16 w-16 items-center justify-center rounded-full bg-blue-50 mx-auto mb-4">
+        <svg className="h-8 w-8 text-blue-500 animate-spin" fill="none" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+        </svg>
+      </div>
+    );
+  }
+  return (
+    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-amber-100 mx-auto mb-4">
+      <svg className="h-8 w-8 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M12 15v2m0 0v2m0-2h2m-2 0H10m2-6V7m0 0V5m0 2h2m-2 0H10M4.93 4.93l14.14 14.14" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4" />
+      </svg>
+    </div>
+  );
+}
+
+// ─── Confirmation Modal ───────────────────────────────────────────────────────
+
+interface ConfirmModalProps {
+  escrowId: string;
+  deliveryId: string;
+  walletAddress: string;
+  amount?: string;
+  currency?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ConfirmModal({
+  amount,
+  currency,
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  // Close on overlay click
+  const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.target === overlayRef.current) onCancel();
+  };
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="escrow-modal-title"
+    >
+      <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl">
+        <div className="flex h-14 w-14 items-center justify-center rounded-full bg-amber-100 mx-auto mb-4">
+          <svg className="h-7 w-7 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+          </svg>
+        </div>
+
+        <h2 id="escrow-modal-title" className="text-center text-lg font-semibold text-gray-900 mb-1">
+          Confirm Delivery & Release Payment
+        </h2>
+        <p className="text-center text-sm text-gray-500 mb-5">
+          This will release{' '}
+          <span className="font-medium text-gray-900">
+            {amount && currency ? `${amount} ${currency}` : 'the escrowed funds'}
+          </span>{' '}
+          to the driver. This action cannot be undone.
+        </p>
+
+        <div className="rounded-xl border border-gray-100 bg-gray-50 p-4 mb-5 space-y-1 text-sm">
+          <div className="flex justify-between text-gray-600">
+            <span>Action</span>
+            <span className="font-medium text-gray-900">Release escrow</span>
+          </div>
+          {amount && currency && (
+            <div className="flex justify-between text-gray-600">
+              <span>Amount</span>
+              <span className="font-medium text-gray-900">{amount} {currency}</span>
+            </div>
+          )}
+          <div className="flex justify-between text-gray-600">
+            <span>Recipient</span>
+            <span className="font-medium text-gray-900">Driver</span>
+          </div>
+        </div>
+
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-xl border border-gray-200 bg-white py-2.5 text-sm font-medium text-gray-700 transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-300"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 rounded-xl bg-green-600 py-2.5 text-sm font-medium text-white transition hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+          >
+            Yes, Release Payment
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Component ───────────────────────────────────────────────────────────
+
+/**
+ * EscrowRelease — allows a recipient to confirm delivery and release the
+ * escrowed payment to the driver.
+ *
+ * Follows the strict Component → Hook → Service layered architecture.
+ */
+export function EscrowRelease({ escrowId, deliveryId }: EscrowReleaseProps) {
+  const address = useWalletStore((s) => s.address);
+  const isConnected = useWalletStore((s) => s.isConnected);
+
+  const {
+    escrowDetails,
+    step,
+    isLoading,
+    transactionHash,
+    fetchEscrowDetails,
+    openConfirmDialog,
+    confirmAndRelease,
+    reset,
+  } = useEscrowRelease();
+
+  useEffect(() => {
+    fetchEscrowDetails(escrowId);
+  }, [escrowId, fetchEscrowDetails]);
+
+  const isActionDisabled =
+    !isConnected ||
+    !address ||
+    step !== 'idle' ||
+    escrowDetails?.status !== 'locked';
+
+  const handleMainButtonClick = () => {
+    openConfirmDialog(escrowId, deliveryId, address ?? '');
+  };
+
+  const handleConfirm = () => {
+    confirmAndRelease(escrowId, deliveryId, address ?? '');
+  };
+
+  const handleCancel = () => {
+    reset();
+  };
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
+        <div className="animate-pulse space-y-3">
+          <div className="h-4 w-1/3 rounded bg-gray-100" />
+          <div className="h-3 w-2/3 rounded bg-gray-100" />
+          <div className="h-10 w-full rounded-xl bg-gray-100" />
+        </div>
+      </div>
+    );
+  }
+
+  // ── Not connected ──────────────────────────────────────────────────────────
+  if (!isConnected) {
+    return (
+      <div className="rounded-2xl border border-amber-200 bg-amber-50 p-5 text-center">
+        <p className="text-sm font-medium text-amber-800">
+          Connect your wallet to release the escrow payment.
+        </p>
+      </div>
+    );
+  }
+
+  // ── Already released ───────────────────────────────────────────────────────
+  if (escrowDetails?.status === 'released') {
+    return (
+      <div className="rounded-2xl border border-green-200 bg-green-50 p-6 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-green-100 mx-auto mb-3">
+          <svg className="h-6 w-6 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <p className="text-sm font-semibold text-green-800">Payment Already Released</p>
+        <p className="mt-1 text-xs text-green-600">The escrowed funds have been sent to the driver.</p>
+      </div>
+    );
+  }
+
+  // ── Main UI ────────────────────────────────────────────────────────────────
+  return (
+    <>
+      <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm space-y-5">
+        {/* Header */}
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">Release Escrow Payment</h3>
+          <p className="mt-1 text-sm text-gray-500">
+            Confirm the delivery was received to release payment to the driver.
+          </p>
+        </div>
+
+        {/* Escrow summary */}
+        {escrowDetails && (
+          <div className="rounded-xl border border-gray-100 bg-gray-50 p-4 space-y-2 text-sm">
+            <div className="flex justify-between text-gray-600">
+              <span>Escrow ID</span>
+              <span className="font-mono font-medium text-gray-900 text-xs">
+                {escrowDetails.id.slice(0, 12)}…
+              </span>
+            </div>
+            <div className="flex justify-between text-gray-600">
+              <span>Amount</span>
+              <span className="font-semibold text-gray-900">
+                {escrowDetails.amount} {escrowDetails.currency}
+              </span>
+            </div>
+            <div className="flex justify-between text-gray-600">
+              <span>Status</span>
+              <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                escrowDetails.status === 'locked'
+                  ? 'bg-blue-100 text-blue-700'
+                  : escrowDetails.status === 'released'
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-red-100 text-red-700'
+              }`}>
+                {escrowDetails.status.charAt(0).toUpperCase() + escrowDetails.status.slice(1)}
+              </span>
+            </div>
+          </div>
+        )}
+
+        {/* In-progress status */}
+        {(step === 'signing' || step === 'releasing') && (
+          <div className="rounded-xl border border-blue-100 bg-blue-50 p-4 text-center">
+            <StatusIcon step={step} />
+            <p className="text-sm font-medium text-blue-800">{STEP_LABEL[step]}</p>
+            <p className="mt-1 text-xs text-blue-600">{STEP_DESCRIPTION[step]}</p>
+          </div>
+        )}
+
+        {/* Done state */}
+        {step === 'done' && (
+          <div className="rounded-xl border border-green-100 bg-green-50 p-4 text-center">
+            <StatusIcon step="done" />
+            <p className="text-sm font-semibold text-green-800">Payment Released!</p>
+            {transactionHash && (
+              <p className="mt-1 text-xs text-green-600 font-mono break-all">
+                Tx: {transactionHash}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Main action button */}
+        <button
+          onClick={handleMainButtonClick}
+          disabled={isActionDisabled}
+          aria-busy={step === 'signing' || step === 'releasing'}
+          className={`w-full rounded-xl py-3 text-sm font-semibold transition focus:outline-none focus:ring-2 focus:ring-offset-2 ${
+            step === 'done'
+              ? 'bg-green-100 text-green-700 cursor-not-allowed'
+              : isActionDisabled
+              ? 'bg-gray-100 text-gray-400 cursor-not-allowed'
+              : 'bg-green-600 text-white hover:bg-green-700 focus:ring-green-500 active:scale-[0.98]'
+          }`}
+        >
+          {STEP_LABEL[step]}
+        </button>
+
+        {/* Wallet address display */}
+        {address && (
+          <p className="text-center text-xs text-gray-400">
+            Wallet:{' '}
+            <span className="font-mono">
+              {address.slice(0, 6)}…{address.slice(-4)}
+            </span>
+          </p>
+        )}
+      </div>
+
+      {/* Confirmation modal — rendered when step === 'confirming' */}
+      {step === 'confirming' && (
+        <ConfirmModal
+          escrowId={escrowId}
+          deliveryId={deliveryId}
+          walletAddress={address ?? ''}
+          amount={escrowDetails?.amount}
+          currency={escrowDetails?.currency}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+        />
+      )}
+    </>
+  );
+}

--- a/hooks/useEscrowRelease.ts
+++ b/hooks/useEscrowRelease.ts
@@ -1,0 +1,114 @@
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+import { escrowService, EscrowDetails } from '@/services/escrowService';
+
+export type ReleaseStep = 'idle' | 'confirming' | 'signing' | 'releasing' | 'done';
+
+interface UseEscrowReleaseReturn {
+  escrowDetails: EscrowDetails | null;
+  step: ReleaseStep;
+  isLoading: boolean;
+  transactionHash: string | null;
+  fetchEscrowDetails: (escrowId: string) => Promise<void>;
+  openConfirmDialog: (escrowId: string, deliveryId: string, walletAddress: string) => void;
+  confirmAndRelease: (escrowId: string, deliveryId: string, walletAddress: string) => Promise<void>;
+  reset: () => void;
+}
+
+/**
+ * useEscrowRelease — manages the full escrow release flow.
+ *
+ * Step flow:
+ *   idle → confirming (modal shown) → signing (wallet prompt) →
+ *   releasing (API in-flight) → done (tx confirmed)
+ *
+ * On any failure the step resets to idle and an error toast fires.
+ */
+export function useEscrowRelease(): UseEscrowReleaseReturn {
+  const [escrowDetails, setEscrowDetails] = useState<EscrowDetails | null>(null);
+  const [step, setStep] = useState<ReleaseStep>('idle');
+  const [isLoading, setIsLoading] = useState(false);
+  const [transactionHash, setTransactionHash] = useState<string | null>(null);
+
+  const fetchEscrowDetails = useCallback(async (escrowId: string) => {
+    setIsLoading(true);
+    try {
+      const response = await escrowService.getEscrowDetails(escrowId);
+      if (response.success && response.data) {
+        setEscrowDetails(response.data);
+      } else {
+        toast.error(response.message ?? 'Failed to load escrow details.');
+      }
+    } catch {
+      toast.error('Unable to fetch escrow details. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const openConfirmDialog = useCallback(
+    (_escrowId: string, _deliveryId: string, walletAddress: string) => {
+      if (!walletAddress) {
+        toast.error('No wallet connected. Please connect your wallet first.');
+        return;
+      }
+      setStep('confirming');
+    },
+    []
+  );
+
+  const confirmAndRelease = useCallback(
+    async (escrowId: string, deliveryId: string, walletAddress: string) => {
+      try {
+        setStep('signing');
+        toast.info('Please approve the transaction in your wallet…');
+
+        setStep('releasing');
+        const result = await escrowService.releaseEscrow({
+          escrowId,
+          deliveryId,
+          walletAddress,
+        });
+
+        if (!result.success) {
+          throw new Error(result.message ?? 'Release failed.');
+        }
+
+        setTransactionHash(result.transactionHash ?? null);
+        setStep('done');
+        toast.success(
+          result.transactionHash
+            ? `Payment released! Tx: ${result.transactionHash.slice(0, 12)}…`
+            : 'Payment released successfully!'
+        );
+        setEscrowDetails((prev) =>
+          prev ? { ...prev, status: 'released' as const } : prev
+        );
+      } catch (err: unknown) {
+        setStep('idle');
+        const message =
+          err instanceof Error
+            ? err.message
+            : 'Transaction failed or was rejected. Please try again.';
+        toast.error(message);
+      }
+    },
+    []
+  );
+
+  const reset = useCallback(() => {
+    setStep('idle');
+    setTransactionHash(null);
+  }, []);
+
+  return {
+    escrowDetails,
+    step,
+    isLoading,
+    transactionHash,
+    fetchEscrowDetails,
+    openConfirmDialog,
+    confirmAndRelease,
+    reset,
+  };
+}

--- a/services/escrowService.ts
+++ b/services/escrowService.ts
@@ -1,0 +1,64 @@
+import axios from 'axios';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export interface EscrowDetails {
+  id: string;
+  deliveryId: string;
+  amount: string;
+  currency: string;
+  status: 'locked' | 'released' | 'disputed';
+  sender: string;
+  recipient: string;
+  driver: string;
+  lockedAt: string;
+}
+
+export interface ReleaseEscrowParams {
+  escrowId: string;
+  deliveryId: string;
+  walletAddress: string;
+  signature?: string;
+}
+
+export interface ReleaseEscrowResponse {
+  success: boolean;
+  message: string;
+  transactionHash?: string;
+  releasedAmount?: string;
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data?: T;
+}
+
+/**
+ * escrowService — responsible for all escrow-related API communication.
+ * The hook calls this; components never call this directly.
+ */
+export const escrowService = {
+  async getEscrowDetails(escrowId: string): Promise<ApiResponse<EscrowDetails>> {
+    const { data } = await axios.get<ApiResponse<EscrowDetails>>(
+      `${API_BASE_URL}/api/escrow/${escrowId}`
+    );
+    return data;
+  },
+
+  async releaseEscrow(params: ReleaseEscrowParams): Promise<ReleaseEscrowResponse> {
+    const { data } = await axios.post<ReleaseEscrowResponse>(
+      `${API_BASE_URL}/api/escrow/release`,
+      params
+    );
+    return data;
+  },
+
+  async confirmDelivery(deliveryId: string, walletAddress: string): Promise<ApiResponse<void>> {
+    const { data } = await axios.post<ApiResponse<void>>(
+      `${API_BASE_URL}/api/deliveries/${deliveryId}/confirm`,
+      { walletAddress }
+    );
+    return data;
+  },
+};


### PR DESCRIPTION
Closes #33

## Summary
Implements the Escrow Release / Payout UI — an interface for recipients to confirm delivery and trigger the release of escrowed funds to the driver.

## Changes

- `services/escrowService.ts` — API service with `getEscrowDetails()`, `releaseEscrow()`, and `confirmDelivery()` following the existing service pattern
- `hooks/useEscrowRelease.ts` — hook managing the full release state machine (idle → confirming → signing → releasing → done)
- `features/escrow/components/EscrowRelease.tsx` — main component with confirmation modal, wallet prompt, and all status states

## Architecture
Follows the required Component → Hook → Service layered pattern throughout.

## Key behaviour
- **Submit button is disabled** if wallet is not connected or escrow is not in `locked` state
- **Confirmation modal** shows escrow details (amount, currency, recipient) before any action is taken
- **Wallet prompt toast** fires during the signing step
- **Error toast** fires on transaction failure or wallet rejection — step resets to idle so user can retry
- **Success state** shows transaction hash and marks escrow as released
- Already-released escrows render a read-only success state instead of the action button

## Screenshot
[attach screenshot of the component running locally]