### PR TITLE
feat(wallet): create wallet account dropdown menu

### DIFF
--- a/components/wallet/AccountMenu.tsx
+++ b/components/wallet/AccountMenu.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { Menu, MenuButton, MenuItem, MenuItems } from '@headlessui/react';
+import { ChevronDown, Copy, Check, LogOut } from 'lucide-react';
+import { useAccountMenu } from '@/hooks/useAccountMenu';
+
+/**
+ * AccountMenu — wallet status dropdown for the application header.
+ *
+ * Layered Architecture:
+ *   AccountMenu (Component) → useAccountMenu (Hook) → useWallet → walletService (Service)
+ *
+ * Features:
+ *   - Truncated Stellar public key in the trigger button
+ *   - Full address revealed in the dropdown header
+ *   - Copy address to clipboard with a 2-second confirmation flash
+ *   - Disconnect wallet (calls backend API via service layer)
+ *   - Keyboard accessible: arrow keys navigate items, Enter activates, Escape closes
+ *   - Closes on outside click (Headless UI Menu behaviour)
+ *
+ * Renders nothing when no wallet is connected.
+ */
+export function AccountMenu() {
+  const {
+    address,
+    isConnected,
+    isCopied,
+    isDisconnecting,
+    truncatedAddress,
+    copyAddress,
+    disconnect,
+  } = useAccountMenu();
+
+  if (!isConnected || !address) return null;
+
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      {/* Trigger button — shows green dot + truncated public key */}
+      <MenuButton
+        aria-label="Wallet account menu"
+        className="flex items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700"
+      >
+        <span
+          className="h-2 w-2 shrink-0 rounded-full bg-green-500"
+          aria-hidden="true"
+        />
+        <span
+          className="max-w-[120px] truncate font-mono text-xs"
+          title={address}
+        >
+          {truncatedAddress}
+        </span>
+        <ChevronDown
+          size={14}
+          aria-hidden="true"
+          className="shrink-0 text-slate-400 transition ui-open:rotate-180"
+        />
+      </MenuButton>
+
+      {/* Dropdown panel */}
+      <MenuItems
+        anchor="bottom end"
+        className="z-50 mt-2 w-64 origin-top-right rounded-xl border border-slate-200 bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:ring-white/10"
+      >
+        {/* Full address header — not a focusable menu item */}
+        <div className="border-b border-slate-100 px-4 py-3 dark:border-slate-700">
+          <p className="text-xs font-medium text-slate-500 dark:text-slate-400">
+            Connected Wallet
+          </p>
+          <p
+            className="mt-1 break-all font-mono text-xs text-slate-800 dark:text-slate-200"
+            title={address}
+          >
+            {address}
+          </p>
+        </div>
+
+        <div className="py-1">
+          {/* Copy address */}
+          <MenuItem>
+            <button
+              type="button"
+              onClick={() => void copyAddress()}
+              className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-slate-700 transition data-[focus]:bg-slate-100 data-[focus]:text-slate-900 dark:text-slate-300 dark:data-[focus]:bg-slate-700 dark:data-[focus]:text-white"
+            >
+              {isCopied ? (
+                <Check size={15} className="text-green-500" aria-hidden="true" />
+              ) : (
+                <Copy size={15} aria-hidden="true" />
+              )}
+              <span>{isCopied ? 'Address Copied!' : 'Copy Address'}</span>
+            </button>
+          </MenuItem>
+
+          {/* Disconnect wallet */}
+          <MenuItem>
+            <button
+              type="button"
+              disabled={isDisconnecting}
+              onClick={() => void disconnect()}
+              className="flex w-full items-center gap-3 px-4 py-2.5 text-sm text-red-600 transition disabled:cursor-not-allowed disabled:opacity-60 data-[focus]:bg-red-50 data-[focus]:text-red-700 dark:text-red-400 dark:data-[focus]:bg-red-900/30 dark:data-[focus]:text-red-300"
+            >
+              {isDisconnecting ? (
+                <span
+                  className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"
+                />
+              ) : (
+                <LogOut size={15} aria-hidden="true" />
+              )}
+              <span>{isDisconnecting ? 'Disconnecting…' : 'Disconnect Wallet'}</span>
+            </button>
+          </MenuItem>
+        </div>
+      </MenuItems>
+    </Menu>
+  );
+}

--- a/hooks/__tests__/useAccountMenu.test.ts
+++ b/hooks/__tests__/useAccountMenu.test.ts
@@ -1,0 +1,136 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAccountMenu } from '@/hooks/useAccountMenu';
+
+const mockDisconnect = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@/hooks/useWallet', () => ({
+  useWallet: jest.fn(() => ({
+    address: 'GABC123DEF456STELLAR',
+    isConnected: true,
+    disconnect: mockDisconnect,
+  })),
+}));
+
+// Provide clipboard API in jsdom
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn().mockResolvedValue(undefined),
+  },
+});
+
+describe('useAccountMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('reflects connected state and address from useWallet', () => {
+    const { result } = renderHook(() => useAccountMenu());
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.address).toBe('GABC123DEF456STELLAR');
+  });
+
+  it('returns truncated address as first-6 … last-6 characters', () => {
+    const { result } = renderHook(() => useAccountMenu());
+    expect(result.current.truncatedAddress).toBe('GABC12…TELLAR');
+  });
+
+  it('starts with isCopied as false', () => {
+    const { result } = renderHook(() => useAccountMenu());
+    expect(result.current.isCopied).toBe(false);
+  });
+
+  it('starts with isDisconnecting as false', () => {
+    const { result } = renderHook(() => useAccountMenu());
+    expect(result.current.isDisconnecting).toBe(false);
+  });
+
+  describe('copyAddress', () => {
+    it('writes the full address to the clipboard', async () => {
+      const { result } = renderHook(() => useAccountMenu());
+      await act(async () => {
+        await result.current.copyAddress();
+      });
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        'GABC123DEF456STELLAR'
+      );
+    });
+
+    it('sets isCopied to true immediately after copy', async () => {
+      const { result } = renderHook(() => useAccountMenu());
+      await act(async () => {
+        await result.current.copyAddress();
+      });
+      expect(result.current.isCopied).toBe(true);
+    });
+
+    it('resets isCopied to false after 2 seconds', async () => {
+      const { result } = renderHook(() => useAccountMenu());
+      await act(async () => {
+        await result.current.copyAddress();
+      });
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+      expect(result.current.isCopied).toBe(false);
+    });
+
+    it('does nothing when address is null', async () => {
+      const { useWallet } = jest.requireMock('@/hooks/useWallet');
+      useWallet.mockReturnValueOnce({
+        address: null,
+        isConnected: false,
+        disconnect: mockDisconnect,
+      });
+      const { result } = renderHook(() => useAccountMenu());
+      await act(async () => {
+        await result.current.copyAddress();
+      });
+      expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('disconnect', () => {
+    it('calls the underlying useWallet disconnect', async () => {
+      const { result } = renderHook(() => useAccountMenu());
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets isDisconnecting to false after disconnect resolves', async () => {
+      const { result } = renderHook(() => useAccountMenu());
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(result.current.isDisconnecting).toBe(false);
+    });
+
+    it('resets isDisconnecting to false even when disconnect throws', async () => {
+      mockDisconnect.mockRejectedValueOnce(new Error('Network failure'));
+      const { result } = renderHook(() => useAccountMenu());
+      await act(async () => {
+        await result.current.disconnect();
+      });
+      expect(result.current.isDisconnecting).toBe(false);
+    });
+  });
+
+  describe('truncatedAddress edge cases', () => {
+    it('returns empty string when address is null', () => {
+      const { useWallet } = jest.requireMock('@/hooks/useWallet');
+      useWallet.mockReturnValueOnce({
+        address: null,
+        isConnected: false,
+        disconnect: mockDisconnect,
+      });
+      const { result } = renderHook(() => useAccountMenu());
+      expect(result.current.truncatedAddress).toBe('');
+    });
+  });
+});

--- a/hooks/useAccountMenu.ts
+++ b/hooks/useAccountMenu.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useWallet } from '@/hooks/useWallet';
+
+export interface UseAccountMenuResult {
+  address: string | null;
+  isConnected: boolean;
+  isCopied: boolean;
+  isDisconnecting: boolean;
+  truncatedAddress: string;
+  copyAddress: () => Promise<void>;
+  disconnect: () => Promise<void>;
+}
+
+/**
+ * useAccountMenu — state and actions for the wallet account header dropdown.
+ *
+ * Layered Architecture:
+ *   AccountMenu (Component) → useAccountMenu (Hook) → useWallet → walletService (Service)
+ *
+ * The wallet address originates from the backend API response (walletService.connect).
+ * This hook derives the truncated display and adds clipboard + disconnect orchestration.
+ */
+export function useAccountMenu(): UseAccountMenuResult {
+  const { address, isConnected, disconnect: disconnectWallet } = useWallet();
+  const [isCopied, setIsCopied] = useState(false);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const truncatedAddress = address
+    ? `${address.slice(0, 6)}…${address.slice(-6)}`
+    : '';
+
+  const copyAddress = useCallback(async (): Promise<void> => {
+    if (!address) return;
+    await navigator.clipboard.writeText(address);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000);
+  }, [address]);
+
+  const disconnect = useCallback(async (): Promise<void> => {
+    setIsDisconnecting(true);
+    try {
+      await disconnectWallet();
+    } finally {
+      setIsDisconnecting(false);
+    }
+  }, [disconnectWallet]);
+
+  return {
+    address,
+    isConnected,
+    isCopied,
+    isDisconnecting,
+    truncatedAddress,
+    copyAddress,
+    disconnect,
+  };
+}


### PR DESCRIPTION
## Summary

Implements the wallet account header dropdown menu as specified in issue #31.

### What was built

- **`hooks/useAccountMenu.ts`** — hook layer that wraps `useWallet` and exposes:
  - `truncatedAddress` — first-6 `…` last-6 characters of the Stellar public key
  - `copyAddress()` — writes the full address to the clipboard, sets `isCopied` for 2 s
  - `disconnect()` — delegates to `useWallet.disconnect()` (calls `walletService.disconnect` → backend API) with local `isDisconnecting` loading flag

- **`components/wallet/AccountMenu.tsx`** — Headless UI `Menu` dropdown that:
  - Renders `null` when no wallet is connected (no-op when unauthenticated)
  - Shows a green dot + truncated public key in the trigger button
  - Exposes the full address in a non-interactive dropdown header
  - **Copy Address** item: clipboard write with a `Check` icon confirmation flash
  - **Disconnect Wallet** item: spinner while in-flight, disabled during request
  - Keyboard accessible out-of-the-box (arrow keys, Enter, Escape) via Headless UI
  - Closes on outside click via Headless UI `Menu` behaviour
  - Full dark mode support via Tailwind `dark:` variants

- **`hooks/__tests__/useAccountMenu.test.ts`** — 11 unit tests covering:
  - Connected state and address reflection from `useWallet`
  - Correct truncation (`GABC12…TELLAR` pattern)
  - Clipboard write on `copyAddress()`
  - `isCopied` flag lifecycle (true immediately, resets after 2 s)
  - No-op when address is null
  - `isDisconnecting` flag lifecycle (resets on resolve and on throw)
  - Empty `truncatedAddress` when disconnected

### Architecture

Follows the strict **Component → Hook → Service** layered pattern:

AccountMenu (Component)
↓
useAccountMenu (Hook)
↓
useWallet (Hook)
↓
walletService / freighterService (Service)
↓
Backend API  (/api/wallet/connect, /api/wallet/disconnect)


The wallet `address` displayed in the dropdown is sourced from the backend API response (`walletService.connect`) stored in Zustand — no inline mock objects.

### Tech

- Tailwind CSS (dark mode, `data-[focus]` variants)
- `@headlessui/react` v2 `Menu` (keyboard navigation + outside-click close)
- `lucide-react` icons (ChevronDown, Copy, Check, LogOut)

Closes #31


