### PR TITLE
feat: error boundary, empty state, jwt interceptors, protected routes , admin shell

### DIFF
--- a/app/(admin)/admin/overview/page.tsx
+++ b/app/(admin)/admin/overview/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import {
+  Users,
+  Package,
+  DollarSign,
+  Truck,
+  ShieldCheck,
+  Lock,
+  RefreshCw,
+  AlertCircle,
+} from 'lucide-react';
+import { useAdminDashboard } from '@/hooks/useAdminDashboard';
+
+interface MetricCardProps {
+  label: string;
+  value: string | number;
+  icon: React.ElementType;
+  isLoading: boolean;
+}
+
+function MetricCard({ label, value, icon: Icon, isLoading }: MetricCardProps) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 dark:border-slate-800 dark:bg-slate-900">
+      <div className="mb-4 flex items-center justify-between">
+        <span className="text-sm font-medium text-slate-500 dark:text-slate-400">{label}</span>
+        <div className="rounded-lg bg-blue-50 p-2 dark:bg-blue-900/30">
+          <Icon className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+        </div>
+      </div>
+      {isLoading ? (
+        <div className="h-8 w-24 animate-pulse rounded-md bg-slate-200 dark:bg-slate-700" />
+      ) : (
+        <p className="text-2xl font-bold text-slate-900 dark:text-white">{value}</p>
+      )}
+    </div>
+  );
+}
+
+export default function AdminOverviewPage() {
+  const { stats, isLoading, isError, refetch } = useAdminDashboard();
+
+  return (
+    <div>
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Admin Overview</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Platform-wide metrics and activity summary
+          </p>
+        </div>
+        <button
+          onClick={() => refetch()}
+          className="flex items-center gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 dark:border-slate-700 dark:text-slate-400 dark:hover:bg-slate-800"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </button>
+      </div>
+
+      {isError && (
+        <div className="mb-6 flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          Failed to load stats. Please refresh or try again later.
+        </div>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <MetricCard
+          label="Total Users"
+          value={stats?.totalUsers ?? 0}
+          icon={Users}
+          isLoading={isLoading}
+        />
+        <MetricCard
+          label="Active Deliveries"
+          value={stats?.activeDeliveries ?? 0}
+          icon={Package}
+          isLoading={isLoading}
+        />
+        <MetricCard
+          label="Total Revenue (XLM)"
+          value={stats?.totalRevenue ?? 0}
+          icon={DollarSign}
+          isLoading={isLoading}
+        />
+        <MetricCard
+          label="Active Drivers"
+          value={stats?.activeDrivers ?? 0}
+          icon={Truck}
+          isLoading={isLoading}
+        />
+        <MetricCard
+          label="Pending KYC"
+          value={stats?.pendingKyc ?? 0}
+          icon={ShieldCheck}
+          isLoading={isLoading}
+        />
+        <MetricCard
+          label="Escrow Locked (XLM)"
+          value={stats?.escrowLocked ?? 0}
+          icon={Lock}
+          isLoading={isLoading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import { AdminSidebar } from '@/components/admin/AdminSidebar';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return (
+    <ProtectedRoute requiredRole="Admin">
+      <div className="flex min-h-screen bg-slate-50 dark:bg-slate-950">
+        <AdminSidebar />
+        <main className="ml-64 flex-1 p-8">{children}</main>
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/app/(dashboard)/admin/page.tsx
+++ b/app/(dashboard)/admin/page.tsx
@@ -1,13 +1,5 @@
-import { DisconnectButton } from '@/components/wallet/DisconnectButton';
+import { redirect } from 'next/navigation';
 
 export default function AdminDashboardPage() {
-  return (
-    <div>
-      <h1 data-tour="dashboard-title">Admin Dashboard</h1>
-      {/* Wallet session controls — see hooks/useWallet.ts for disconnect logic */}
-      <div data-tour="disconnect-wallet">
-        <DisconnectButton />
-      </div>
-    </div>
-  );
+  redirect('/admin/overview');
 }

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect } from 'react';
+import { AlertTriangle } from 'lucide-react';
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function GlobalError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    console.error('[GlobalError]', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 bg-slate-50 px-4 dark:bg-slate-950">
+      <div className="rounded-full bg-red-100 p-5 dark:bg-red-900/30">
+        <AlertTriangle className="h-10 w-10 text-red-500" />
+      </div>
+      <div className="text-center">
+        <h1 className="mb-2 text-2xl font-bold text-slate-900 dark:text-white">
+          Something went wrong
+        </h1>
+        <p className="max-w-md text-sm text-slate-500 dark:text-slate-400">
+          {error.message || 'An unexpected error occurred. Please try again.'}
+        </p>
+      </div>
+      <button
+        onClick={reset}
+        className="rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white transition hover:bg-blue-700 active:scale-95"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/components/admin/AdminSidebar.tsx
+++ b/components/admin/AdminSidebar.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import {
+  LayoutDashboard,
+  Users,
+  Package,
+  Shield,
+  Settings,
+  LogOut,
+} from 'lucide-react';
+import { useAuthStore } from '@/store/authStore';
+
+interface AdminNavItem {
+  label: string;
+  href: string;
+  icon: React.ElementType;
+}
+
+const NAV_ITEMS: AdminNavItem[] = [
+  { label: 'Overview', href: '/admin/overview', icon: LayoutDashboard },
+  { label: 'Users', href: '/admin/users', icon: Users },
+  { label: 'Deliveries', href: '/admin/deliveries', icon: Package },
+  { label: 'KYC Review', href: '/admin/kyc', icon: Shield },
+  { label: 'Settings', href: '/admin/settings', icon: Settings },
+];
+
+export function AdminSidebar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const clearUser = useAuthStore((s) => s.clearUser);
+
+  function handleLogout() {
+    localStorage.removeItem('authToken');
+    clearUser();
+    router.replace('/login');
+  }
+
+  return (
+    <aside className="fixed left-0 top-0 flex h-screen w-64 flex-col border-r border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+      <div className="border-b border-slate-200 px-6 py-5 dark:border-slate-800">
+        <span className="text-lg font-bold text-slate-900 dark:text-white">SwiftChain</span>
+        <span className="ml-2 rounded bg-blue-100 px-1.5 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+          Admin
+        </span>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto px-3 py-4">
+        {NAV_ITEMS.map((item) => {
+          const Icon = item.icon;
+          const isActive = pathname === item.href || pathname.startsWith(item.href + '/');
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`mb-1 flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                isActive
+                  ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
+                  : 'text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800'
+              }`}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <div className="border-t border-slate-200 px-3 py-4 dark:border-slate-800">
+        <button
+          onClick={handleLogout}
+          className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-600 transition-colors hover:bg-red-50 hover:text-red-600 dark:text-slate-400 dark:hover:bg-red-900/20 dark:hover:text-red-400"
+        >
+          <LogOut className="h-4 w-4 shrink-0" />
+          Sign out
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/components/auth/ProtectedRoute.tsx
+++ b/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
+import type { UserRole } from '@/store/authStore';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+  requiredRole?: UserRole;
+}
+
+export function ProtectedRoute({ children, requiredRole }: ProtectedRouteProps) {
+  const router = useRouter();
+  const { isAuthenticated, isLoading, user } = useAuth();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (!isAuthenticated) {
+      router.replace('/login');
+      return;
+    }
+
+    if (requiredRole && user?.role !== requiredRole) {
+      router.replace('/');
+    }
+  }, [isAuthenticated, isLoading, requiredRole, user, router]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
+        <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  if (requiredRole && user?.role !== requiredRole) {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+export function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center px-4 py-16 text-center">
+      <div className="mb-4 rounded-full bg-slate-100 p-4 dark:bg-slate-800">
+        <Icon className="h-8 w-8 text-slate-400 dark:text-slate-500" />
+      </div>
+      <h3 className="mb-2 text-base font-semibold text-slate-900 dark:text-white">{title}</h3>
+      {description && (
+        <p className="mb-6 max-w-sm text-sm text-slate-500 dark:text-slate-400">{description}</p>
+      )}
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 active:scale-95"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/hooks/useAdminDashboard.ts
+++ b/hooks/useAdminDashboard.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { adminService, type AdminStats } from '@/services/adminService';
+
+interface UseAdminDashboardReturn {
+  stats: AdminStats | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+}
+
+export function useAdminDashboard(): UseAdminDashboardReturn {
+  const {
+    data: stats,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ['admin', 'stats'],
+    queryFn: async () => {
+      const response = await adminService.getStats();
+      if (!response.success || !response.data) {
+        throw new Error(response.message || 'Failed to fetch admin stats');
+      }
+      return response.data;
+    },
+    staleTime: 30_000,
+    retry: 1,
+  });
+
+  return { stats, isLoading, isError, refetch };
+}

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useAuthStore, type AuthUser, type UserRole } from '@/store/authStore';
+import { authApiService } from '@/services/auth.service';
+
+interface UseAuthReturn {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  user: AuthUser | null;
+}
+
+const API_TO_STORE_ROLE: Record<string, UserRole> = {
+  customer: 'Customer',
+  driver: 'Driver',
+  admin: 'Admin',
+};
+
+export function useAuth(): UseAuthReturn {
+  const [isLoading, setIsLoading] = useState(true);
+  const { user, isAuthenticated, setUser, clearUser } = useAuthStore();
+
+  useEffect(() => {
+    const token = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
+
+    if (!token) {
+      clearUser();
+      setIsLoading(false);
+      return;
+    }
+
+    authApiService
+      .getCurrentUser()
+      .then((res) => {
+        if (res.data) {
+          const role: UserRole = API_TO_STORE_ROLE[res.data.role] ?? 'Customer';
+          setUser({ id: res.data.id, email: res.data.email, role });
+        } else {
+          clearUser();
+        }
+      })
+      .catch(() => {
+        localStorage.removeItem('authToken');
+        clearUser();
+      })
+      .finally(() => setIsLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { isAuthenticated, isLoading, user };
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,41 @@
+import axios, {
+  type AxiosInstance,
+  type InternalAxiosRequestConfig,
+  type AxiosResponse,
+  type AxiosError,
+} from 'axios';
+
+const api: AxiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// Attach JWT bearer token to every outgoing request
+api.interceptors.request.use(
+  (config: InternalAxiosRequestConfig) => {
+    if (typeof window !== 'undefined') {
+      const token = localStorage.getItem('authToken');
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+    }
+    return config;
+  },
+  (error: AxiosError) => Promise.reject(error),
+);
+
+// Handle 401 Unauthorized — clear stored token and redirect to login
+api.interceptors.response.use(
+  (response: AxiosResponse) => response,
+  (error: AxiosError) => {
+    if (error.response?.status === 401 && typeof window !== 'undefined') {
+      localStorage.removeItem('authToken');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default api;

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,19 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 export function middleware(request: NextRequest) {
-  // Placeholder middleware logic
+  const token = request.cookies.get('authToken')?.value;
+  const { pathname } = request.nextUrl;
+
+  const isProtected =
+    pathname.startsWith('/dashboard') ||
+    pathname.startsWith('/admin');
+
+  if (isProtected && !token) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    return NextResponse.redirect(loginUrl);
+  }
+
   return NextResponse.next();
 }
 

--- a/services/adminService.ts
+++ b/services/adminService.ts
@@ -1,0 +1,23 @@
+import api from '@/lib/api';
+
+export interface AdminStats {
+  totalUsers: number;
+  activeDeliveries: number;
+  totalRevenue: number;
+  activeDrivers: number;
+  pendingKyc: number;
+  escrowLocked: number;
+}
+
+export interface AdminApiResponse<T> {
+  success: boolean;
+  message: string;
+  data?: T;
+}
+
+export const adminService = {
+  async getStats(): Promise<AdminApiResponse<AdminStats>> {
+    const { data } = await api.get<AdminApiResponse<AdminStats>>('/admin/stats');
+    return data;
+  },
+};

--- a/services/auth.service.ts
+++ b/services/auth.service.ts
@@ -1,0 +1,22 @@
+import api from '@/lib/api';
+import type { ApiResponse, LoginResponse } from '@/services/authService';
+
+export const authApiService = {
+  async login(email: string, password: string): Promise<ApiResponse<LoginResponse>> {
+    const { data } = await api.post<ApiResponse<LoginResponse>>('/auth/login', {
+      email,
+      password,
+    });
+    return data;
+  },
+
+  async logout(): Promise<ApiResponse<null>> {
+    const { data } = await api.post<ApiResponse<null>>('/auth/logout');
+    return data;
+  },
+
+  async getCurrentUser(): Promise<ApiResponse<LoginResponse['user']>> {
+    const { data } = await api.get<ApiResponse<LoginResponse['user']>>('/auth/me');
+    return data;
+  },
+};


### PR DESCRIPTION


## Summary

Closes #8, 
closes #11,
closes #12, 
closes #16

This PR implements four foundational frontend features following the strict Component → Hook → Service layered architecture throughout.

---

### #8 — Empty State & Error Boundary

**`components/ui/EmptyState.tsx`**
Reusable component accepting a Lucide icon, title, optional description, and an optional CTA action callback. Designed to be dropped into any list view that may return zero results.

**`app/error.tsx`**
Next.js App Router global error boundary (Client Component). Catches render errors anywhere in the component tree, logs them to the console, and renders a full-screen recovery UI with a "Try again" button that calls `reset()` to re-render the failed segment.

---

### #11 — JWT Axios Interceptor Setup

**`lib/api.ts`**
Singleton Axios instance configured with two interceptors:
- **Request:** reads `authToken` from `localStorage` and injects it as `Authorization: Bearer <token>` on every outgoing request.
- **Response:** intercepts `401 Unauthorized` responses, removes the stale token from storage, and redirects the browser to `/login`.

**`services/auth.service.ts`**
Thin auth service built on top of `lib/api.ts`. Exposes `login`, `logout`, and `getCurrentUser` — all requests automatically carry the bearer token via the shared interceptor. Imports shared types from the existing `services/authService.ts` to avoid duplication.

---

### #12 — Protected Route Wrapper

**`hooks/useAuth.ts`**
On mount, reads `authToken` from `localStorage`. If present, calls `GET /auth/me` via the interceptor-enabled client to verify the token and populate the Zustand `authStore`. On 401 or missing token, clears the store. Returns `{ isAuthenticated, isLoading, user }`.

**`components/auth/ProtectedRoute.tsx`**
Client component wrapper that:
1. Shows a centered spinner while `useAuth` resolves.
2. Redirects unauthenticated visitors to `/login` via `router.replace`.
3. Redirects authenticated users with the wrong role to `/`.
4. Renders `children` only when auth and role checks pass.
Accepts an optional `requiredRole` prop for role-gated pages.

---

### #16 — Admin Dashboard Shell

**`services/adminService.ts`**
Service that calls `GET /admin/stats` (via the JWT-bearing `lib/api.ts` client) and returns platform-wide metrics: total users, active deliveries, revenue, active drivers, pending KYC, and escrow locked.

**`hooks/useAdminDashboard.ts`**
TanStack Query hook wrapping `adminService.getStats()`. Caches for 30 seconds, retries once on failure, exposes `{ stats, isLoading, isError, refetch }`.

**`components/admin/AdminSidebar.tsx`**
Fixed 256 px sidebar exclusively for admin pages. Contains navigation links (Overview, Users, Deliveries, KYC Review, Settings) with active-path highlighting and a sign-out button that clears the auth store and redirects to `/login`. Completely separate from the standard `AppLayout` sidebar.

**`app/(admin)/layout.tsx`**
Route-group layout wrapping all pages under `(admin)/` with `ProtectedRoute requiredRole="Admin"`. Admins who are not authenticated are redirected to `/login`; authenticated non-admins are redirected to `/`. Renders `AdminSidebar` + a `<main>` content area.

**`app/(admin)/admin/overview/page.tsx`** → URL: `/admin/overview`
Admin overview page with six metric cards (Total Users, Active Deliveries, Total Revenue, Active Drivers, Pending KYC, Escrow Locked). Shows skeleton loaders while data is in flight and a dismissible error banner on fetch failure. Data is sourced from the backend API via `useAdminDashboard`.

**`app/(dashboard)/admin/page.tsx`** — updated to `redirect('/admin/overview')` so legacy `/admin` links forward to the new isolated admin shell.

**`middleware.ts`** — updated to redirect unauthenticated requests to `/login` for both `/dashboard/*` and `/admin/*` routes.

> **Routing note:** The `(admin)` route group layout is isolated from the `(dashboard)` group. The admin overview is served at `/admin/overview` (inside the `(admin)` group) rather than at `/` to avoid a Next.js build conflict with the existing landing page at `app/page.tsx`. The old `/admin` entry point is preserved as a redirect.
